### PR TITLE
Fix composer text rendering

### DIFF
--- a/requirements_mock.txt
+++ b/requirements_mock.txt
@@ -1,4 +1,4 @@
-moviepy==2.0.0
+moviepy==1.0.3
 numpy
 pillow<10
 tqdm


### PR DESCRIPTION
## Summary
- pin moviepy to 1.0.3 for compatibility
- make ImageMagick binary detection cross-platform
- avoid ImageMagick by generating text overlays with Pillow

## Testing
- `bash setup.sh`
- `python main_test.py`

------
https://chatgpt.com/codex/tasks/task_e_684e02f0ecbc832f9d25cdcf49a4204a