### PR TITLE
Fix paths for mock mode and dynamic ImageMagick lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Utilisez les fichiers suivants pour tester sans télécharger de vidéo ni appel
 
 - `test_data/mock_transcript.txt` : transcript texte simulé  
 - `test_data/mock_segments.json` : segments vidéo simulés  
-- `test_data/mock_part1.png`, `test_data/mock_part2.png` : images utilisées à la place de vidéos
+- `test_data/test/parts/mock_part1.png`, `test_data/test/parts/mock_part2.png` : images utilisées à la place de vidéos
 
 ## 📦 Installation automatique via Internet (recommandé)
 

--- a/generators/youtube/composer.py
+++ b/generators/youtube/composer.py
@@ -3,10 +3,19 @@ from moviepy.config import change_settings
 from utils.logger import get_logger
 from PIL import Image, ImageDraw, ImageColor
 import numpy as np
-import os, random
+import os, random, shutil
 
 logger = get_logger(__name__)
-change_settings({"IMAGEMAGICK_BINARY": "C:/Program Files/ImageMagick-7.1.1-Q16-HDRI/magick.exe"})
+
+# Recherche dynamique de l'exécutable ImageMagick pour rester compatible Linux/Windows
+default_magick = r"C:/Program Files/ImageMagick-7.1.1-Q16-HDRI/magick.exe"
+im_bin = (
+    os.environ.get("IMAGEMAGICK_BINARY")
+    or shutil.which("magick")
+    or shutil.which("convert")
+    or default_magick
+)
+change_settings({"IMAGEMAGICK_BINARY": im_bin})
 
 MODE_TEST = False
 

--- a/requirements_mock.txt
+++ b/requirements_mock.txt
@@ -1,4 +1,9 @@
-moviepy==2.0.0
+moviepy==1.0.3
 numpy
 pillow<10
 tqdm
+imageio
+imageio-ffmpeg
+decorator
+python-dotenv
+openai

--- a/test_data/mock_segmets.json
+++ b/test_data/mock_segmets.json
@@ -2,11 +2,11 @@
   {
     "start": 0.0,
     "end": 5.0,
-    "path": "test_data/mock_part1.png"
+    "path": "test/parts/mock_part1.png"
   },
   {
     "start": 5.0,
     "end": 10.0,
-    "path": "test_data/mock_part2.png"
+    "path": "test/parts/mock_part2.png"
   }
 ]


### PR DESCRIPTION
## Summary
- make ImageMagick path dynamic in `composer.py`
- update requirements for mock environment
- fix mock segment paths and documentation

## Testing
- `bash setup.sh`
- `python main_test.py` *(fails: ImageMagick security policy blocks convert)*

------
https://chatgpt.com/codex/tasks/task_e_684dff900408832f9cb97a82448d56e5